### PR TITLE
Fix parameters passed to update:pre middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,7 +1118,7 @@ are available:
     - pre(payload, Log)
     - post(payload, result, Log)
 * update: 
-    - pre(payload, Log)
+    - pre(\_id, payload, Log)
     - post(payload, result, Log)
 * delete: 
     - pre(\_id, hardDelete, Log)


### PR DESCRIPTION
I was facing an issue with middleware update:pre and figure out that [the documentation was missing](https://github.com/JKHeadley/rest-hapi#middleware) the first parameter `_id` that is passed [in agreement with the source code](https://github.com/JKHeadley/rest-hapi/blob/master/utilities/handler-helper.js#L453).